### PR TITLE
fix internal to handle error

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -36,8 +36,8 @@ func Action(c *cli.Context) error {
 	}
 
 	var gitOrgName string
-	gitURL, _ := exec.Command("git", "config", "--get", "remote.origin.url").Output()
-	if len(gitURL) == 0 {
+	gitURL, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+	if err != nil || len(gitURL) == 0 {
 		gitOrgName = path.Base(pwd)
 	} else {
 		gitOrgName = path.Base(path.Dir(string(gitURL)))


### PR DESCRIPTION
*Description of changes:*
A fix that explicitly handles err.

If we run `git-credential-substitute` in a location where the `.git` directory doesn't exist, we get an error. In that case, we can explicitly set `path.Base(pwd)` to `gitOrgName` .